### PR TITLE
refactor: :memo: move learning objectives to right after intro

### DIFF
--- a/inst/tutorials/lda/lda.Rmd
+++ b/inst/tutorials/lda/lda.Rmd
@@ -15,14 +15,6 @@ library(learnr)
 
 Welcome to the tutorial on **Life Data Analysis**! In this tutorial, you will learn about the basics of life data analysis and how to apply it to various fields, such as the automotive industry.
 
-## What is Life Data Analysis?
-
-Life data analysis is the study of how systems, from machines to people, function over time. For example, in the automotive industry, life data helps explain how long cars will last before they break down. 
-
-## Why is Life Data Analysis Important?
-
-Understanding life data analysis helps in predicting the lifespan and maintenance needs of various systems, thereby improving reliability and efficiency. By collecting and modeling life data, we can make predictions about how long cars will last or how long before they will need to be repaired or replaced. 
-
 ## Learning Objectives
 
 By the end of this module, learners will be able to:
@@ -32,6 +24,14 @@ By the end of this module, learners will be able to:
 * Differentiate between different Weibull models (2-parameter Weibull, 3-parameter Weibull, and Weibayes).
 * Apply Median Rank Regression (MRR) and Maximum Likelihood Estimation (MLE) estimation methods to sample datasets.
 * Interpret results using plotting methods, including probability plots and contour plots.
+
+## What is Life Data Analysis?
+
+Life data analysis is the study of how systems, from machines to people, function over time. For example, in the automotive industry, life data helps explain how long cars will last before they break down. 
+
+## Why is Life Data Analysis Important?
+
+Understanding life data analysis helps in predicting the lifespan and maintenance needs of various systems, thereby improving reliability and efficiency. By collecting and modeling life data, we can make predictions about how long cars will last or how long before they will need to be repaired or replaced. 
 
 ## Weibull Analysis
 

--- a/inst/tutorials/ram/ram.Rmd
+++ b/inst/tutorials/ram/ram.Rmd
@@ -16,6 +16,16 @@ library(WeibullR.learnr)
 
 Welcome to the tutorial on **Reliability, Availability, and Maintainability (RAM)**! In this tutorial, you will learn about these fundamental concepts and their applications.
 
+## Learning Objectives
+
+By the end of this module, learners will be able to:
+
+* Define key reliability metrics, including reliability, availability, and failure rate.
+* Describe the significance of MTTR, MTTF, and MTBF in reliability engineering.
+* Calculate probability of failure using given reliability data.
+* Interpret $B_n$ or $L_n$ life values in the context of product reliability.
+* Differentiate between different reliability measures.
+
 ## What is RAM?
 
 The terms Reliability, Availability, and Maintainability may sound similar, but they actually represent different concepts.
@@ -27,16 +37,6 @@ The terms Reliability, Availability, and Maintainability may sound similar, but 
 **Maintainability**: The ease and speed with which an item can be restored to operational status after a failure.
 
 That being said, all 3 terms are inter-related. A car that is not very reliable is probably not available very often. A car that is also difficult to maintain is probably available even less. 
-
-## Learning Objectives
-
-By the end of this module, learners will be able to:
-
-* Define key reliability metrics, including reliability, availability, and failure rate.
-* Describe the significance of MTTR, MTTF, and MTBF in reliability engineering.
-* Calculate probability of failure using given reliability data.
-* Interpret $B_n$ or $L_n$ life values in the context of product reliability.
-* Differentiate between different reliability measures.
 
 ## Reliability
 

--- a/inst/tutorials/rt/rt.Rmd
+++ b/inst/tutorials/rt/rt.Rmd
@@ -15,14 +15,6 @@ library(learnr)
 
 Welcome to the tutorial on **Reliability Testing**! In this tutorial, you will learn about different types of reliability tests and how to apply them. These models are commonly applied in industries like aerospace, automotive, and electronics, where improving product reliability over time is critical.
 
-## What is Reliability Testing?
-
-Reliability testing is a process to ensure that a product or system performs its intended functions under specified conditions over a defined period. For example, in the automotive industry, we may want to design a car that runs without breaking down for 5 to 10 years. 
-
-## Why is Reliability Testing important?
-
-Reliability testing helps organizations predict the future reliability of products, reduce failure rates, and lower costs associated with repairs and downtime. 
-
 ## Learning Objectives
 
 By the end of this tutorial, learners will be able to:
@@ -34,6 +26,14 @@ By the end of this tutorial, learners will be able to:
 * Conduct accelerated life tests with real-world datasets, utilizing R for analysis.
 * Interpret accelerated life testing plots to identify trends.
 * Analyze the impact of stress factors on product reliability using Arrhenius and Power Law models.
+
+## What is Reliability Testing?
+
+Reliability testing is a process to ensure that a product or system performs its intended functions under specified conditions over a defined period. For example, in the automotive industry, we may want to design a car that runs without breaking down for 5 to 10 years. 
+
+## Why is Reliability Testing important?
+
+Reliability testing helps organizations predict the future reliability of products, reduce failure rates, and lower costs associated with repairs and downtime. 
 
 ## Reliability Growth Analysis
 


### PR DESCRIPTION
Connected to the review here: https://github.com/openjournals/jose-reviews/issues/302

Learning objectives should be described as soon as possible. So I moved them up to be right after the introduction, rather than after "learning material" about what the topics are.

If the content in the headers below are part of the introduction, then move them out of those headers and into the introduction, since each header in Shiny is a new page.